### PR TITLE
Memory Leak on Tracks

### DIFF
--- a/AlbumFactory/AlbumFactory/Data/Track.swift
+++ b/AlbumFactory/AlbumFactory/Data/Track.swift
@@ -13,7 +13,9 @@ public struct Track: Decodable, Equatable, Identifiable {
     // MARK: - Properties
     // MARK: Immutable
 
-    public let id = UUID()
+    public var id: String {
+        "\(name) \(duration ?? 0)  \(visitUrl ?? "")"
+    }
     public let name: String
     public let duration: Int?
     public let visitUrl: String?

--- a/AlbumFactory/AlbumFactory/Features/Album/AlbumDetailsViewModel.swift
+++ b/AlbumFactory/AlbumFactory/Features/Album/AlbumDetailsViewModel.swift
@@ -98,7 +98,7 @@ class AlbumDetailsViewModel: ObservableObject {
     // MARK: - Helpers
 
     private func handleResponse(_ album: Album, isNetworkData: Bool) {
-        if !album.tracks.isEmpty {
+        if !album.tracks.isEmpty && isNetworkData {
             self.album.updateTracks(tracks: album.tracks)
             storeManager.updateAlbumTracks(album: self.album)
         }

--- a/AlbumFactory/AlbumFactory/Features/Artist/ArtistAlbumsViewModel.swift
+++ b/AlbumFactory/AlbumFactory/Features/Artist/ArtistAlbumsViewModel.swift
@@ -66,6 +66,7 @@ class ArtistAlbumsViewModel: ObservableObject {
 
     private func handleResponse(_ artistInfoResponse: ArtistInfoResponse, artistAlbumResponse: ArtistAlbumsResponse) {
         itemViewModels = artistAlbumResponse.albums
+            .filter { !$0.mbid.isEmpty && $0.mbid != "(null)" }
             .map {
                 var album = $0
                 album.updateArtist(artist: artistInfoResponse.artist)


### PR DESCRIPTION
Due to every time having a unique id on Track, we were ending up on updating the tracks every time we opened the AlbumDetails. This PR addresses finding a way to combine name, duration and visitURL to create a unique one